### PR TITLE
Bugfix: certmaker service crashed in portainer

### DIFF
--- a/certmaker/checkforcerts.sh
+++ b/certmaker/checkforcerts.sh
@@ -9,6 +9,8 @@ bothfilesexist(){
   fi
 }
 
+cd /certs;
+
 if bothfilesexist; then
   printf "################\nAll certs exist\n################"
   exit 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     stdin_open: true # docker run -i
     tty: true # docker run -t
     # command: /bin/sh -c "/scripts/checkforcerts.sh"
-    command: sleep infinite
+    command: sleep infinity
   # mysql:
   #   image: mysql:8.0
   #   environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     tty: true # docker run -t
     command: /bin/sh /scripts/checkforcerts.sh
     # command: sh -c "/bin/sh /scripts/checkforcerts.sh; while true; do sleep 86400; done;"
+
   mysql:
     image: mysql:8.0
     environment:
@@ -25,6 +26,9 @@ services:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       timeout: 5s
       retries: 20
+      depends_on:
+        certmaker:
+          condition: service_completed_successfully
 
   redis:
     image: redis:latest
@@ -32,6 +36,9 @@ services:
       - "6379:6379"
     volumes:
       - redis_data:/data
+    depends_on:
+      certmaker:
+        condition: service_completed_successfully
 
   fleet:
     image: fleetdm/fleet:v4.55.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,10 @@ services:
     volumes:
       - ./certmaker:/scripts
       - certs:/certsvolume
-    command: /bin/sh -c "/scripts/checkforcerts.sh"
+    stdin_open: true # docker run -i
+    tty: true # docker run -t
+    # command: /bin/sh -c "/scripts/checkforcerts.sh"
+    command: sleep infinite
   # mysql:
   #   image: mysql:8.0
   #   environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,53 +7,53 @@ services:
       - ./certmaker:/scripts
       - certs:/certsvolume
     command: /bin/sh -c "/scripts/checkforcerts.sh"
-  mysql:
-    image: mysql:8.0
-    environment:
-      MYSQL_ROOT_PASSWORD: password
-      MYSQL_DATABASE: fleet
-      MYSQL_USER: fleet
-      MYSQL_PASSWORD: fleet
-    ports:
-      - "3306:3306"
-    volumes:
-      - mysql_data:/var/lib/mysql
-    healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
-      timeout: 5s
-      retries: 20
+  # mysql:
+  #   image: mysql:8.0
+  #   environment:
+  #     MYSQL_ROOT_PASSWORD: password
+  #     MYSQL_DATABASE: fleet
+  #     MYSQL_USER: fleet
+  #     MYSQL_PASSWORD: fleet
+  #   ports:
+  #     - "3306:3306"
+  #   volumes:
+  #     - mysql_data:/var/lib/mysql
+  #   healthcheck:
+  #     test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+  #     timeout: 5s
+  #     retries: 20
 
-  redis:
-    image: redis:latest
-    ports:
-      - "6379:6379"
-    volumes:
-      - redis_data:/data
+  # redis:
+  #   image: redis:latest
+  #   ports:
+  #     - "6379:6379"
+  #   volumes:
+  #     - redis_data:/data
 
-  fleet:
-    image: fleetdm/fleet:v4.55.1
-    environment:
-      FLEET_MYSQL_ADDRESS: mysql:3306
-      FLEET_MYSQL_USERNAME: fleet
-      FLEET_MYSQL_PASSWORD: fleet
-      FLEET_MYSQL_DATABASE: fleet
-      FLEET_REDIS_ADDRESS: redis:6379
-      FLEET_SERVER_CERT: /certs/cert.pem
-      FLEET_SERVER_KEY: /certs/key.pem
-    ports:
-      - "8080:8080"
-    stdin_open: true # docker run -i
-    tty: true # docker run -t
-    volumes:
-      - certs:/certs
-    command: sh -c "fleet serve || fleet prepare db && fleet serve;"
-    depends_on:
-      certmaker:
-        condition: service_completed_successfully
-      mysql:
-        condition: service_started
-      redis:
-        condition: service_started
+  # fleet:
+  #   image: fleetdm/fleet:v4.55.1
+  #   environment:
+  #     FLEET_MYSQL_ADDRESS: mysql:3306
+  #     FLEET_MYSQL_USERNAME: fleet
+  #     FLEET_MYSQL_PASSWORD: fleet
+  #     FLEET_MYSQL_DATABASE: fleet
+  #     FLEET_REDIS_ADDRESS: redis:6379
+  #     FLEET_SERVER_CERT: /certs/cert.pem
+  #     FLEET_SERVER_KEY: /certs/key.pem
+  #   ports:
+  #     - "8080:8080"
+  #   stdin_open: true # docker run -i
+  #   tty: true # docker run -t
+  #   volumes:
+  #     - certs:/certs
+  #   command: sh -c "fleet serve || fleet prepare db && fleet serve;"
+  #   depends_on:
+  #     certmaker:
+  #       condition: service_completed_successfully
+  #     mysql:
+  #       condition: service_started
+  #     redis:
+  #       condition: service_started
 
 volumes:
   mysql_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     stdin_open: true # docker run -i
     tty: true # docker run -t
     # command: /bin/sh -c "/scripts/checkforcerts.sh"
-    command: sleep infinity
+    command: while true; do sleep 86400; done
   # mysql:
   #   image: mysql:8.0
   #   environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
     volumes:
       - ./certmaker:/scripts
       - certs:/certsvolume
-    stdin_open: true # docker run -i
-    tty: true # docker run -t
     command: /bin/sh /scripts/checkforcerts.sh
 
   mysql:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
     stdin_open: true # docker run -i
     tty: true # docker run -t
     command: /bin/sh /scripts/checkforcerts.sh
-    # command: sh -c "/bin/sh /scripts/checkforcerts.sh; while true; do sleep 86400; done;"
 
   mysql:
     image: mysql:8.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,53 +10,53 @@ services:
     tty: true # docker run -t
     command: /bin/sh /scripts/checkforcerts.sh
     # command: sh -c "/bin/sh /scripts/checkforcerts.sh; while true; do sleep 86400; done;"
-  # mysql:
-  #   image: mysql:8.0
-  #   environment:
-  #     MYSQL_ROOT_PASSWORD: password
-  #     MYSQL_DATABASE: fleet
-  #     MYSQL_USER: fleet
-  #     MYSQL_PASSWORD: fleet
-  #   ports:
-  #     - "3306:3306"
-  #   volumes:
-  #     - mysql_data:/var/lib/mysql
-  #   healthcheck:
-  #     test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
-  #     timeout: 5s
-  #     retries: 20
+  mysql:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: fleet
+      MYSQL_USER: fleet
+      MYSQL_PASSWORD: fleet
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      timeout: 5s
+      retries: 20
 
-  # redis:
-  #   image: redis:latest
-  #   ports:
-  #     - "6379:6379"
-  #   volumes:
-  #     - redis_data:/data
+  redis:
+    image: redis:latest
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
 
-  # fleet:
-  #   image: fleetdm/fleet:v4.55.1
-  #   environment:
-  #     FLEET_MYSQL_ADDRESS: mysql:3306
-  #     FLEET_MYSQL_USERNAME: fleet
-  #     FLEET_MYSQL_PASSWORD: fleet
-  #     FLEET_MYSQL_DATABASE: fleet
-  #     FLEET_REDIS_ADDRESS: redis:6379
-  #     FLEET_SERVER_CERT: /certs/cert.pem
-  #     FLEET_SERVER_KEY: /certs/key.pem
-  #   ports:
-  #     - "8080:8080"
-  #   stdin_open: true # docker run -i
-  #   tty: true # docker run -t
-  #   volumes:
-  #     - certs:/certs
-  #   command: sh -c "fleet serve || fleet prepare db && fleet serve;"
-  #   depends_on:
-  #     certmaker:
-  #       condition: service_completed_successfully
-  #     mysql:
-  #       condition: service_started
-  #     redis:
-  #       condition: service_started
+  fleet:
+    image: fleetdm/fleet:v4.55.1
+    environment:
+      FLEET_MYSQL_ADDRESS: mysql:3306
+      FLEET_MYSQL_USERNAME: fleet
+      FLEET_MYSQL_PASSWORD: fleet
+      FLEET_MYSQL_DATABASE: fleet
+      FLEET_REDIS_ADDRESS: redis:6379
+      FLEET_SERVER_CERT: /certs/cert.pem
+      FLEET_SERVER_KEY: /certs/key.pem
+    ports:
+      - "8080:8080"
+    stdin_open: true # docker run -i
+    tty: true # docker run -t
+    volumes:
+      - certs:/certs
+    command: sh -c "fleet serve || fleet prepare db && fleet serve;"
+    depends_on:
+      certmaker:
+        condition: service_completed_successfully
+      mysql:
+        condition: service_started
+      redis:
+        condition: service_started
 
 volumes:
   mysql_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     stdin_open: true # docker run -i
     tty: true # docker run -t
     # command: /bin/sh -c "/scripts/checkforcerts.sh"
-    command: while true; do sleep 86400; done
+    command: sh -c "while true; do sleep 86400; done;"
   # mysql:
   #   image: mysql:8.0
   #   environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     stdin_open: true # docker run -i
     tty: true # docker run -t
     # command: /bin/sh -c "/scripts/checkforcerts.sh"
-    command: sh -c "while true; do sleep 86400; done;"
+    command: sh -c "/bin/sh -c \"/scripts/checkforcerts.sh\"; while true; do sleep 86400; done;"
   # mysql:
   #   image: mysql:8.0
   #   environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - certs:/certsvolume
     stdin_open: true # docker run -i
     tty: true # docker run -t
-    command: /bin/sh scripts/checkforcerts.sh
+    command: /bin/sh /scripts/checkforcerts.sh
     # command: sh -c "/bin/sh /scripts/checkforcerts.sh; while true; do sleep 86400; done;"
   # mysql:
   #   image: mysql:8.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     stdin_open: true # docker run -i
     tty: true # docker run -t
     # command: /bin/sh -c "/scripts/checkforcerts.sh"
-    command: sh -c "/bin/sh -c \"/scripts/checkforcerts.sh\"; while true; do sleep 86400; done;"
+    command: sh -c "chmod 744 /scripts/checkforcerts.sh; /bin/sh -c \"/scripts/checkforcerts.sh\"; while true; do sleep 86400; done;"
   # mysql:
   #   image: mysql:8.0
   #   environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       - certs:/certsvolume
     stdin_open: true # docker run -i
     tty: true # docker run -t
-    # command: /bin/sh -c "/scripts/checkforcerts.sh"
-    command: sh -c "/bin/sh /scripts/checkforcerts.sh; while true; do sleep 86400; done;"
+    command: /bin/sh scripts/checkforcerts.sh
+    # command: sh -c "/bin/sh /scripts/checkforcerts.sh; while true; do sleep 86400; done;"
   # mysql:
   #   image: mysql:8.0
   #   environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     stdin_open: true # docker run -i
     tty: true # docker run -t
     # command: /bin/sh -c "/scripts/checkforcerts.sh"
-    command: sh -c "chmod 744 /scripts/checkforcerts.sh; /bin/sh -c \"/scripts/checkforcerts.sh\"; while true; do sleep 86400; done;"
+    command: sh -c "/bin/sh /scripts/checkforcerts.sh; while true; do sleep 86400; done;"
   # mysql:
   #   image: mysql:8.0
   #   environment:


### PR DESCRIPTION
## docker-compose.yml
- correct certmaker service command to pass script to sh, rather than run it directly.
- do not start any other services if certmaker fails

## checkforcerts.sh
- explicitly cd into /certs folder before generating certs